### PR TITLE
Fix multiverseBridge API URL to match full schema requirements

### DIFF
--- a/app/multiverseBridgeService.py
+++ b/app/multiverseBridgeService.py
@@ -4,7 +4,7 @@ from requests.adapters import HTTPAdapter
 from requests.packages.urllib3.util.retry import Retry
 
 
-api_url = "multiversebridge.com/api/v1/cards/search?"
+api_url = "http://www.multiversebridge.com//api/v1/cards/search?"
 retry_strategy = Retry(
     total=5,
     status_forcelist=[429, 500, 502, 503, 504],


### PR DESCRIPTION
See issue #1. This fixes the issue by updating the URL to its full form required by the domain's new DNS settings that have made requests without www.* fail.